### PR TITLE
Some fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["hardware-support"]
 include = ["src/**/*", "Cargo.toml", "README.md", "LICENSE"]
 
 [dependencies]
-hid = "^0.4.1"
+hidapi = "^2.4.1"
 error-chain = "^0.11.0"
 
 [badges]

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,13 +1,15 @@
-extern crate hid;
 extern crate cp211x_uart;
+extern crate hidapi;
 
+use cp211x_uart::{DataBits, FlowControl, HidUart, Parity, StopBits, UartConfig};
 use std::time::Duration;
-use cp211x_uart::{HidUart, UartConfig, DataBits, StopBits, Parity, FlowControl};
 
 fn run() -> Result<(), cp211x_uart::Error> {
-    let manager = hid::init()?;
-    for device in manager.find(Some(0x10C4), Some(0xEA80)) {
-        let handle = device.open()?;
+    let manager = hidapi::HidApi::new()?;
+    for device_info in manager.device_list().filter(|device_info| {
+        device_info.vendor_id() == 0x10C4 && device_info.product_id() == 0xEA80
+    }) {
+        let handle = device_info.open_device(&manager)?;
         let mut uart = HidUart::new(handle)?;
 
         let config = UartConfig {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 error_chain! {
     foreign_links {
-        HidError(::hid::Error);
+        HidError(::hidapi::HidError);
     }
 
     errors {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ impl HidUart {
             } else {
                 break;
             }
-            if start_time.elapsed() < self.read_timeout {
+            if start_time.elapsed() > self.read_timeout {
                 break;
             }
         }


### PR DESCRIPTION
Hello,

Thanks for writing this crate!

Unfortunately, I ran into a couple problems:

1. I couldn't open my device -- I believe I was running into this problem here: https://github.com/meh/rust-hid/issues/6
2. After I swapped out `hid` for `hidapi`, I ran into an issue where `read` would request N bytes from the HID layer, which would return a `buffer` wherein `buffer[0]` (i.e. the RX FIFO report length) -- call it M -- was such that M > N. This would then entail writing more bytes to `data` than `data.len()`, causing a `panic`.
3. The logic was reversed for `read`'s timeout.


To resolve No. 2, I did the only thing I could think of: create a buffer within `HidUart` that can handle the worst case scenario of up to the max report length being unused; subsequent reads would first drain that buffer before hitting the HID layer. (Admittedly I *could* save a couple bytes -- `INTERRUPT_REPORT_LENGTH` isn't strictly necessary, since one byte from the report is always the length, and we'll always read at least one byte (otherwise we wouldn't have requested the report in the first place) -- so something like `INTERRUPT_REPORT_LENGTH - 2` for this buffer's size should suffice, but I figured I'd keep it simple).

Hopefully the other changes are pretty straightforward, but I'd be happy to answer any questions and/or implement any feedback.

I'm currently using this branch while I develop my [ut61e-rs](https://github.com/cstrahan/ut61e-rs/) crate, which provides a means for reading measurement messages from the UT61E digital multi-meter, and it's going well so far, for what that's worth.